### PR TITLE
Pass inventory and switch to kubeconfig for input/output

### DIFF
--- a/dcipipeline/main.py
+++ b/dcipipeline/main.py
@@ -52,7 +52,7 @@ library            = {dci_ansible_dir}/modules/
 module_utils       = {dci_ansible_dir}/module_utils/
 callback_whitelist = dci
 callback_plugins   = {dci_ansible_dir}/callback/
-interpreter_python = /usr/bin/python2
+roles_path         = /usr/share/dci/roles/:/var/lib/dci-openshift-agent/baremetal_deploy_repo/ansible-ipi-install/roles/
 
 '''.format(dci_ansible_dir=dci_ansible_dir))
 
@@ -138,6 +138,7 @@ def run_ocp(stage, dci_credentials, envvars, data_dir, job_info):
         verbosity=VERBOSE_LEVEL,
         envvars=envvars,
         extravars=extravars,
+        inventory=stage['inventory'],
         quiet=False)
     log.info(run.stats)
 
@@ -161,6 +162,7 @@ def run_cnf(stage, dci_credentials, envvars, data_dir, job_info):
         verbosity=VERBOSE_LEVEL,
         envvars=envvars,
         extravars=extravars,
+        inventory=stage['inventory'],
         quiet=False)
     log.info(run.stats)
     return run.rc == 0

--- a/dcipipeline/pipeline.yml
+++ b/dcipipeline/pipeline.yml
@@ -2,8 +2,9 @@
   - name: openshift-vanilla
     type: ocp
     location: agents/openshift-vanilla
+    inventory: agents/openshift-vanilla
     outputs:
-      hosts: agents/openshift-vanilla/outputs/localhost/etc/hosts
+      kubeconfig: agents/openshift-vanilla/outputs/localhost/kubeconfig
     topic: OCP-4.4
     success_tag: ocp-vanilla-ok
     fallback_last_success: ocp-vanilla-ok
@@ -12,7 +13,7 @@
     type: cnf
     location: agents/rh-cnf
     inputs:
-      hosts: agents/rh-cnf/hosts
+      kubeconfig: agents/rh-cnf/kubeconfig
     topic: RH-CNF-0.1
     success_tag: ocp-vanilla-ok
     fallback_last_success: ocp-vanilla-ok


### PR DESCRIPTION
Moved to inputs/outputs to kubeconfig and pass inventory to ansible_runner so we can run multiple at once.